### PR TITLE
Add GitHub Rule: Auto-approve bugfix PR's

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Auto-Approve Bugfix Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - development
+    types: [opened, reopened]
+
+jobs:
+  auto-approve-bugfix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check branch name
+        id: check_branch
+        run: |
+          if [[ "${{ github.head_ref }}" == bugfix/* ]]; then
+            echo "IS_BUGFIX=true" >> $GITHUB_ENV
+          else
+            echo "IS_BUGFIX=false" >> $GITHUB_ENV
+
+      - name: Auto-approve bugfix PRs
+        if: env.IS_BUGFIX == 'true'
+        uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added a GitHub Action to automatically approve Pull Requests to the Development branch that come from a /bugfix/* branch. This allows for bugfixes to not require other developers approval, while still maintaining that feature branches must be approved by others before a merge.